### PR TITLE
🧹 Changing turns should not update the last active time for lobby

### DIFF
--- a/src/application/commands/change-turn.command.ts
+++ b/src/application/commands/change-turn.command.ts
@@ -34,10 +34,6 @@ class ChangeTurnCommand extends Command {
 
     gameState.nextTurn();
 
-    if (gameState.lobby) {
-      gameState.lobby.lastActivityTime = Date.now();
-    }
-
     this.io.to(lobbyId).emit('ChangeTurn', gameState);
   }
 }

--- a/src/application/services/game.service.ts
+++ b/src/application/services/game.service.ts
@@ -120,6 +120,8 @@ class GameService {
       // Set the parsed gameState in gameStates map
       gameState.setLobby(lobbyEntity);
       gameState.setTable(tableEntity);
+      // Just to make sure the current player gets set properly
+      gameState.currentPlayerIndex = json.currentPlayerIndex;
       this.setGameState(gameState);
 
       if (gameState) {


### PR DESCRIPTION
Changing turns are now also automatic, every 30 seconds the turn changes. Which means resources would never get freed if it also updates the lobby's last active time.